### PR TITLE
[BEAM-4410] added BroadcastJoinTranslator

### DIFF
--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/BrodcastHashJoinTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/BrodcastHashJoinTranslator.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.euphoria.beam;
+
+import static org.apache.beam.sdk.extensions.euphoria.beam.common.OperatorTranslatorUtil.getKVInputCollection;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.extensions.euphoria.beam.io.KryoCoder;
+import org.apache.beam.sdk.extensions.euphoria.beam.window.BeamWindowing;
+import org.apache.beam.sdk.extensions.euphoria.core.client.dataset.Dataset;
+import org.apache.beam.sdk.extensions.euphoria.core.client.dataset.windowing.Window;
+import org.apache.beam.sdk.extensions.euphoria.core.client.dataset.windowing.Windowing;
+import org.apache.beam.sdk.extensions.euphoria.core.client.functional.BinaryFunctor;
+import org.apache.beam.sdk.extensions.euphoria.core.client.operator.Join;
+import org.apache.beam.sdk.extensions.euphoria.core.client.operator.Operator;
+import org.apache.beam.sdk.extensions.euphoria.core.client.operator.hint.SizeHint;
+import org.apache.beam.sdk.extensions.euphoria.core.client.util.Pair;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+
+/**
+ * Translator for {@link org.apache.beam.sdk.extensions.euphoria.core.client.operator.RightJoin} and
+ * {@link org.apache.beam.sdk.extensions.euphoria.core.client.operator.LeftJoin} when one side of
+ * the join fits in memory so it can be distributed in hashmap with the other side.
+ */
+public class BrodcastHashJoinTranslator implements OperatorTranslator<Join> {
+
+  public static boolean hasFitsInMemoryHint(Operator operator) {
+    return operator != null
+        && operator.getHints() != null
+        && operator.getHints().contains(SizeHint.FITS_IN_MEMORY);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public PCollection<?> translate(Join operator, BeamExecutorContext context) {
+    return doTranslate(operator, context);
+  }
+
+  <K, LeftT, RightT, OutputT, W extends Window<W>> PCollection<Pair<K, OutputT>> doTranslate(
+      Join<LeftT, RightT, K, OutputT, W> operator, BeamExecutorContext context) {
+    Coder<K> keyCoder = context.getCoder(operator.getLeftKeyExtractor());
+
+    @SuppressWarnings("unchecked") final PCollection<LeftT> left = (PCollection<LeftT>) context
+        .getInputs(operator).get(0);
+    @SuppressWarnings("unchecked") final PCollection<RightT> right = (PCollection<RightT>) context
+        .getInputs(operator).get(1);
+
+    final PCollection<KV<K, LeftT>> leftKvInput =
+        getKVInputCollection(
+            left,
+            operator.getLeftKeyExtractor(),
+            keyCoder,
+            new KryoCoder<>(),
+            ":extract-keys-left");
+
+    final PCollection<KV<K, RightT>> rightKvInput =
+        getKVInputCollection(
+            right,
+            operator.getRightKeyExtractor(),
+            keyCoder,
+            new KryoCoder<>(),
+            ":extract-keys-right");
+
+    switch (operator.getType()) {
+      case LEFT:
+        final PCollectionView<Map<K, Iterable<RightT>>> broadcastRight =
+            rightKvInput.apply(View.asMultimap());
+        return leftKvInput.apply(
+            ParDo.of(new BroadcastHashLeftJoinFn<>(broadcastRight, operator.getJoiner()))
+                .withSideInputs(broadcastRight));
+
+      case RIGHT:
+        final PCollectionView<Map<K, Iterable<LeftT>>> broadcastLeft =
+            leftKvInput.apply(View.asMultimap());
+        return rightKvInput.apply(
+            ParDo.of(new BroadcastHashRightJoinFn<>(broadcastLeft, operator.getJoiner()))
+                .withSideInputs(broadcastLeft));
+
+      default:
+        throw new UnsupportedOperationException(
+            String.format(
+                "Cannot translate Euphoria '%s' operator to Beam transformations."
+                    + " Given join type '%s' is not supported for BrodcastHashJoin.",
+                Join.class.getSimpleName(), operator.getType()));
+    }
+  }
+
+  @Override
+  public boolean canTranslate(Join operator) {
+    @SuppressWarnings("unchecked") final ArrayList<Dataset> inputs = new ArrayList(operator.listInputs());
+    if (inputs.size() != 2) {
+      return false;
+    }
+    final Dataset leftDataset = inputs.get(0);
+    final Dataset rightDataset = inputs.get(1);
+    return (operator.getType() == Join.Type.LEFT && hasFitsInMemoryHint(rightDataset.getProducer())
+            || operator.getType() == Join.Type.RIGHT
+                && hasFitsInMemoryHint(leftDataset.getProducer()))
+        && isAllowedWindowing(operator.getWindowing());
+  }
+
+  /**
+   * BroadcastHashJoin supports only GlobalWindow or none.
+   */
+  private boolean isAllowedWindowing(Windowing windowing) {
+    return windowing == null
+        || (windowing instanceof BeamWindowing
+        && ((BeamWindowing) windowing).getWindowFn() instanceof GlobalWindows);
+  }
+
+  static class BroadcastHashRightJoinFn<K, LeftT, RightT, OutputT>
+      extends DoFn<KV<K, RightT>, Pair<K, OutputT>> {
+
+    private final PCollectionView<Map<K, Iterable<LeftT>>> smallSideCollection;
+    private final BinaryFunctor<LeftT, RightT, OutputT> joiner;
+    private final SingleValueCollector<OutputT> outCollector = new SingleValueCollector<>();
+
+    BroadcastHashRightJoinFn(
+        PCollectionView<Map<K, Iterable<LeftT>>> smallSideCollection,
+        BinaryFunctor<LeftT, RightT, OutputT> joiner) {
+      this.smallSideCollection = smallSideCollection;
+      this.joiner = joiner;
+    }
+
+    @SuppressWarnings("unused")
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      final K key = context.element().getKey();
+      final Map<K, Iterable<LeftT>> map = context.sideInput(smallSideCollection);
+      final Iterable<LeftT> leftValues = map.getOrDefault(key, Collections.singletonList(null));
+      leftValues.forEach(
+          leftValue -> {
+            joiner.apply(leftValue, context.element().getValue(), outCollector);
+            context.output(Pair.of(key, outCollector.get()));
+          });
+    }
+  }
+
+  static class BroadcastHashLeftJoinFn<K, LeftT, RightT, OutputT>
+      extends DoFn<KV<K, LeftT>, Pair<K, OutputT>> {
+
+    private final PCollectionView<Map<K, Iterable<RightT>>> smallSideCollection;
+    private final BinaryFunctor<LeftT, RightT, OutputT> joiner;
+    private final SingleValueCollector<OutputT> outCollector = new SingleValueCollector<>();
+
+    BroadcastHashLeftJoinFn(
+        PCollectionView<Map<K, Iterable<RightT>>> smallSideCollection,
+        BinaryFunctor<LeftT, RightT, OutputT> joiner) {
+      this.smallSideCollection = smallSideCollection;
+      this.joiner = joiner;
+    }
+
+    @SuppressWarnings("unused")
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      final K key = context.element().getKey();
+      final Map<K, Iterable<RightT>> map = context.sideInput(smallSideCollection);
+      final Iterable<RightT> rightValues = map.getOrDefault(key, Collections.singletonList(null));
+
+      rightValues.forEach(
+          rightValue -> {
+            joiner.apply(context.element().getValue(), rightValue, outCollector);
+            context.output(Pair.of(key, outCollector.get()));
+          });
+    }
+  }
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/FlowTranslator.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/FlowTranslator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.euphoria.beam;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Collection;
@@ -59,6 +60,7 @@ class FlowTranslator {
     // extended operators
     translators.put(ReduceByKey.class, new ReduceByKeyTranslator());
     translators.put(ReduceStateByKey.class, new ReduceStateByKeyTranslator());
+    translators.put(Join.class, new BrodcastHashJoinTranslator());
     translators.put(Join.class, new JoinTranslator());
   }
 
@@ -78,9 +80,10 @@ class FlowTranslator {
     return false;
   }
 
+  @VisibleForTesting
   @Nullable
   @SuppressWarnings("unchecked")
-  private static OperatorTranslator getTranslatorIfAvailable(Operator operator){
+  static OperatorTranslator getTranslatorIfAvailable(Operator operator) {
     Collection<OperatorTranslator> availableTranslators = translators.get(operator.getClass());
     if (availableTranslators.isEmpty()){
       return null;

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/common/OperatorTranslatorUtil.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/common/OperatorTranslatorUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.euphoria.beam.common;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.extensions.euphoria.core.client.functional.UnaryFunction;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * Shared utility methods among operator translators.
+ */
+public class OperatorTranslatorUtil {
+
+  /**
+   * Transform input to KV elements.
+   */
+  public static <K, ValueT> PCollection<KV<K, ValueT>> getKVInputCollection(
+      PCollection<ValueT> inputPCollection,
+      UnaryFunction<ValueT, K> keyExtractor,
+      Coder<K> keyCoder, Coder<ValueT> valueCoder, String transformName) {
+
+    @SuppressWarnings("unchecked")
+    PCollection<ValueT> typedInput = inputPCollection;
+    typedInput.setCoder(valueCoder);
+
+    PCollection<KV<K, ValueT>> kvInput =
+        typedInput.apply(transformName, ParDo.of(new InputToKvDoFn<>(keyExtractor)));
+    kvInput.setCoder(KvCoder.of(keyCoder, valueCoder));
+
+    return kvInput;
+  }
+
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/org/apache/beam/sdk/extensions/euphoria/beam/JoinTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/org/apache/beam/sdk/extensions/euphoria/beam/JoinTest.java
@@ -18,8 +18,11 @@
 package org.apache.beam.sdk.extensions.euphoria.beam;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
 
 import java.util.Optional;
+import org.apache.beam.sdk.extensions.euphoria.core.client.dataset.Dataset;
 import org.apache.beam.sdk.extensions.euphoria.core.client.flow.Flow;
 import org.apache.beam.sdk.extensions.euphoria.core.client.io.Collector;
 import org.apache.beam.sdk.extensions.euphoria.core.client.io.ListDataSink;
@@ -27,7 +30,9 @@ import org.apache.beam.sdk.extensions.euphoria.core.client.io.ListDataSource;
 import org.apache.beam.sdk.extensions.euphoria.core.client.operator.FullJoin;
 import org.apache.beam.sdk.extensions.euphoria.core.client.operator.Join;
 import org.apache.beam.sdk.extensions.euphoria.core.client.operator.LeftJoin;
+import org.apache.beam.sdk.extensions.euphoria.core.client.operator.MapElements;
 import org.apache.beam.sdk.extensions.euphoria.core.client.operator.RightJoin;
+import org.apache.beam.sdk.extensions.euphoria.core.client.operator.hint.SizeHint;
 import org.apache.beam.sdk.extensions.euphoria.core.client.util.Pair;
 import org.apache.beam.sdk.extensions.euphoria.testing.DatasetAssert;
 import org.junit.Test;
@@ -37,118 +42,35 @@ import org.junit.Test;
  */
 public class JoinTest {
 
-  @Test
-  public void simpleInnerJoinTest() {
-    final Flow flow = Flow.create();
-
-    ListDataSource<Pair<Integer, String>> left =
-        ListDataSource.bounded(
-            asList(
-                Pair.of(1, "L v1"), Pair.of(1, "L v2"),
-                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
-                Pair.of(3, "L v1")
-            ));
-
-    ListDataSource<Pair<Integer, Integer>> right =
-        ListDataSource.bounded(
-            asList(
-                Pair.of(1, 1), Pair.of(1, 10),
-                Pair.of(2, 20),
-                Pair.of(4, 40)
-            ));
-
-    ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
-
-    Join.of(flow.createInput(left), flow.createInput(right))
-        .by(Pair::getFirst, Pair::getFirst)
-        .using(
-            (Pair<Integer, String> l, Pair<Integer, Integer> r, Collector<Pair<String, Integer>> c)
-                -> c.collect(Pair.of(l.getSecond(), r.getSecond())))
-        .output()
-        .persist(output);
-
-    BeamExecutor executor = TestUtils.createExecutor();
-    executor.execute(flow);
-
-    DatasetAssert.unorderedEquals(output.getOutputs(),
-        Pair.of(1, Pair.of("L v1", 1)), Pair.of(1, Pair.of("L v1", 10)),
-        Pair.of(1, Pair.of("L v2", 1)), Pair.of(1, Pair.of("L v2", 10)),
-
-        Pair.of(2, Pair.of("L v1", 20)), Pair.of(2, Pair.of("L v2", 20))
-    );
-
+  static <T> Dataset<T> addFitsInMemoryHint(Dataset<T> smallDataset) {
+    return MapElements.named("smallSide")
+        .of(smallDataset)
+        .using(e -> e)
+        .output(SizeHint.FITS_IN_MEMORY);
   }
 
-  @Test
-  public void simpleLeftJoinTest() {
-    final Flow flow = Flow.create();
+  static void checkBrodcastHashJoinTranslatorUsage(Flow flow) {
+    OperatorTranslator operatorTranslator =
+        flow.operators()
+            .stream()
+            .filter(node -> node instanceof Join)
+            .map(FlowTranslator::getTranslatorIfAvailable)
+            .findFirst()
+            .orElse(null);
 
-    ListDataSource<Pair<Integer, String>> left =
-        ListDataSource.bounded(
-            asList(
-                Pair.of(1, "L v1"), Pair.of(1, "L v2"),
-                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
-                Pair.of(3, "L v1")
-            ));
-
-    ListDataSource<Pair<Integer, Integer>> right =
-        ListDataSource.bounded(
-            asList(
-                Pair.of(1, 1), Pair.of(1, 10),
-                Pair.of(2, 20),
-                Pair.of(4, 40)
-            ));
-
-    ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
-
-    LeftJoin.of(flow.createInput(left), flow.createInput(right))
-        .by(Pair::getFirst, Pair::getFirst)
-        .using((Pair<Integer, String> l, Optional<Pair<Integer, Integer>> r,
-            Collector<Pair<String, Integer>> c) ->
-            c.collect(Pair.of(l.getSecond(), r.orElse(Pair.of(null, null)).getSecond())))
-        .output()
-        .persist(output);
-
-    BeamExecutor executor = TestUtils.createExecutor();
-    executor.execute(flow);
-
-    DatasetAssert.unorderedEquals(output.getOutputs(),
-        Pair.of(1, Pair.of("L v1", 1)), Pair.of(1, Pair.of("L v1", 10)),
-        Pair.of(1, Pair.of("L v2", 1)), Pair.of(1, Pair.of("L v2", 10)),
-
-        Pair.of(2, Pair.of("L v1", 20)), Pair.of(2, Pair.of("L v2", 20)),
-
-        Pair.of(3, Pair.of("L v1", null))
-    );
-
+    assertThat(operatorTranslator, instanceOf(BrodcastHashJoinTranslator.class));
   }
 
-  @Test
-  public void simpleRightJoinTest() {
-    final Flow flow = Flow.create();
-
-    ListDataSource<Pair<Integer, String>> left =
-        ListDataSource.bounded(
-            asList(
-                Pair.of(1, "L v1"), Pair.of(1, "L v2"),
-                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
-                Pair.of(3, "L v1")
-            ));
-
-    ListDataSource<Pair<Integer, Integer>> right =
-        ListDataSource.bounded(
-            asList(
-                Pair.of(1, 1), Pair.of(1, 10),
-                Pair.of(2, 20),
-                Pair.of(4, 40)
-            ));
+  static void checkRightJoin(
+      Flow flow, Dataset<Pair<Integer, String>> left, Dataset<Pair<Integer, Integer>> right) {
 
     ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
 
-    RightJoin.of(flow.createInput(left), flow.createInput(right))
+    RightJoin.of(left, right)
         .by(Pair::getFirst, Pair::getFirst)
         .using(
-            (Optional<Pair<Integer, String>> l, Pair<Integer, Integer> r,
+            (Optional<Pair<Integer, String>> l,
+                Pair<Integer, Integer> r,
                 Collector<Pair<String, Integer>> c) ->
                 c.collect(Pair.of(l.orElse(Pair.of(null, null)).getSecond(), r.getSecond())))
         .output()
@@ -157,60 +79,177 @@ public class JoinTest {
     BeamExecutor executor = TestUtils.createExecutor();
     executor.execute(flow);
 
-    DatasetAssert.unorderedEquals(output.getOutputs(),
-        Pair.of(1, Pair.of("L v1", 1)), Pair.of(1, Pair.of("L v1", 10)),
-        Pair.of(1, Pair.of("L v2", 1)), Pair.of(1, Pair.of("L v2", 10)),
-
-        Pair.of(2, Pair.of("L v1", 20)), Pair.of(2, Pair.of("L v2", 20)),
-
-        Pair.of(4, Pair.of(null, 40))
-    );
-
+    DatasetAssert.unorderedEquals(
+        output.getOutputs(),
+        Pair.of(1, Pair.of("L v1", 1)),
+        Pair.of(1, Pair.of("L v1", 10)),
+        Pair.of(1, Pair.of("L v2", 1)),
+        Pair.of(1, Pair.of("L v2", 10)),
+        Pair.of(2, Pair.of("L v1", 20)),
+        Pair.of(2, Pair.of("L v2", 20)),
+        Pair.of(4, Pair.of(null, 40)));
   }
 
-  @Test
-  public void simpleFullJoinTest() {
-    final Flow flow = Flow.create();
-
-    ListDataSource<Pair<Integer, String>> left =
-        ListDataSource.bounded(
-            asList(
-                Pair.of(1, "L v1"), Pair.of(1, "L v2"),
-                Pair.of(2, "L v1"), Pair.of(2, "L v2"),
-                Pair.of(3, "L v1")
-            ));
-
-    ListDataSource<Pair<Integer, Integer>> right =
-        ListDataSource.bounded(
-            asList(
-                Pair.of(1, 1), Pair.of(1, 10),
-                Pair.of(2, 20),
-                Pair.of(4, 40)
-            ));
+  static void checkLeftJoin(
+      Flow flow, Dataset<Pair<Integer, String>> left, Dataset<Pair<Integer, Integer>> right) {
 
     ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
 
-    FullJoin.of(flow.createInput(left), flow.createInput(right))
+    LeftJoin.of(left, right)
         .by(Pair::getFirst, Pair::getFirst)
-        .using((Optional<Pair<Integer, String>> l, Optional<Pair<Integer, Integer>> r,
-            Collector<Pair<String, Integer>> c) -> c.collect(Pair.of(
-            l.orElse(Pair.of(null, null)).getSecond(), r.orElse(Pair.of(null, null)).getSecond())))
+        .using(
+            (Pair<Integer, String> l,
+                Optional<Pair<Integer, Integer>> r,
+                Collector<Pair<String, Integer>> c) ->
+                c.collect(Pair.of(l.getSecond(), r.orElse(Pair.of(null, null)).getSecond())))
         .output()
         .persist(output);
 
     BeamExecutor executor = TestUtils.createExecutor();
     executor.execute(flow);
 
-    DatasetAssert.unorderedEquals(output.getOutputs(),
-        Pair.of(1, Pair.of("L v1", 1)), Pair.of(1, Pair.of("L v1", 10)),
-        Pair.of(1, Pair.of("L v2", 1)), Pair.of(1, Pair.of("L v2", 10)),
-
-        Pair.of(2, Pair.of("L v1", 20)), Pair.of(2, Pair.of("L v2", 20)),
-
-        Pair.of(3, Pair.of("L v1", null)),
-        Pair.of(4, Pair.of(null, 40))
-    );
-
+    DatasetAssert.unorderedEquals(
+        output.getOutputs(),
+        Pair.of(1, Pair.of("L v1", 1)),
+        Pair.of(1, Pair.of("L v1", 10)),
+        Pair.of(1, Pair.of("L v2", 1)),
+        Pair.of(1, Pair.of("L v2", 10)),
+        Pair.of(2, Pair.of("L v1", 20)),
+        Pair.of(2, Pair.of("L v2", 20)),
+        Pair.of(3, Pair.of("L v1", null)));
   }
 
+  @Test
+  public void simpleInnerJoinTest() {
+    final Flow flow = Flow.create();
+
+    ListDataSource<Pair<Integer, String>> left = getLeftDataSource();
+    ListDataSource<Pair<Integer, Integer>> right = getRightDataSource();
+
+    ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
+
+    Join.of(flow.createInput(left), flow.createInput(right))
+        .by(Pair::getFirst, Pair::getFirst)
+        .using(
+            (Pair<Integer, String> l,
+                Pair<Integer, Integer> r,
+                Collector<Pair<String, Integer>> c) ->
+                c.collect(Pair.of(l.getSecond(), r.getSecond())))
+        .output()
+        .persist(output);
+
+    BeamExecutor executor = TestUtils.createExecutor();
+    executor.execute(flow);
+
+    DatasetAssert.unorderedEquals(
+        output.getOutputs(),
+        Pair.of(1, Pair.of("L v1", 1)),
+        Pair.of(1, Pair.of("L v1", 10)),
+        Pair.of(1, Pair.of("L v2", 1)),
+        Pair.of(1, Pair.of("L v2", 10)),
+        Pair.of(2, Pair.of("L v1", 20)),
+        Pair.of(2, Pair.of("L v2", 20)));
+  }
+
+  @Test
+  public void simpleLeftJoinTest() {
+    final Flow flow = Flow.create();
+
+    ListDataSource<Pair<Integer, String>> left = getLeftDataSource();
+    ListDataSource<Pair<Integer, Integer>> right = getRightDataSource();
+
+    checkLeftJoin(flow, flow.createInput(left), flow.createInput(right));
+  }
+
+  @Test
+  public void simpleRightJoinTest() {
+    final Flow flow = Flow.create();
+
+    ListDataSource<Pair<Integer, String>> left = getLeftDataSource();
+    ListDataSource<Pair<Integer, Integer>> right = getRightDataSource();
+
+    checkRightJoin(flow, flow.createInput(left), flow.createInput(right));
+  }
+
+  @Test
+  public void simpleFullJoinTest() {
+    final Flow flow = Flow.create();
+
+    ListDataSource<Pair<Integer, String>> left = getLeftDataSource();
+    ListDataSource<Pair<Integer, Integer>> right = getRightDataSource();
+
+    ListDataSink<Pair<Integer, Pair<String, Integer>>> output = ListDataSink.get();
+
+    FullJoin.of(flow.createInput(left), flow.createInput(right))
+        .by(Pair::getFirst, Pair::getFirst)
+        .using(
+            (Optional<Pair<Integer, String>> l,
+                Optional<Pair<Integer, Integer>> r,
+                Collector<Pair<String, Integer>> c) ->
+                c.collect(
+                    Pair.of(
+                        l.orElse(Pair.of(null, null)).getSecond(),
+                        r.orElse(Pair.of(null, null)).getSecond())))
+        .output()
+        .persist(output);
+
+    BeamExecutor executor = TestUtils.createExecutor();
+    executor.execute(flow);
+
+    DatasetAssert.unorderedEquals(
+        output.getOutputs(),
+        Pair.of(1, Pair.of("L v1", 1)),
+        Pair.of(1, Pair.of("L v1", 10)),
+        Pair.of(1, Pair.of("L v2", 1)),
+        Pair.of(1, Pair.of("L v2", 10)),
+        Pair.of(2, Pair.of("L v1", 20)),
+        Pair.of(2, Pair.of("L v2", 20)),
+        Pair.of(3, Pair.of("L v1", null)),
+        Pair.of(4, Pair.of(null, 40)));
+  }
+
+  @Test
+  public void simpleBroadcastHashRightJoinTest() {
+    final Flow flow = Flow.create();
+
+    ListDataSource<Pair<Integer, String>> left = getLeftDataSource();
+    ListDataSource<Pair<Integer, Integer>> right = getRightDataSource();
+
+    final Dataset<Pair<Integer, String>> smallLeftSide =
+        addFitsInMemoryHint(flow.createInput(left));
+
+    checkRightJoin(flow, smallLeftSide, flow.createInput(right));
+
+    checkBrodcastHashJoinTranslatorUsage(flow);
+  }
+
+  @Test
+  public void simpleBroadcastHashLefttJoinTest() {
+    final Flow flow = Flow.create();
+
+    ListDataSource<Pair<Integer, String>> left = getLeftDataSource();
+    ListDataSource<Pair<Integer, Integer>> right = getRightDataSource();
+
+    final Dataset<Pair<Integer, Integer>> smallRightSide =
+        addFitsInMemoryHint(flow.createInput(right));
+
+    checkLeftJoin(flow, flow.createInput(left), smallRightSide);
+
+    checkBrodcastHashJoinTranslatorUsage(flow);
+  }
+
+  ListDataSource<Pair<Integer, String>> getLeftDataSource() {
+    return ListDataSource.bounded(
+        asList(
+            Pair.of(1, "L v1"),
+            Pair.of(1, "L v2"),
+            Pair.of(2, "L v1"),
+            Pair.of(2, "L v2"),
+            Pair.of(3, "L v1")));
+  }
+
+  ListDataSource<Pair<Integer, Integer>> getRightDataSource() {
+    return ListDataSource.bounded(
+        asList(Pair.of(1, 1), Pair.of(1, 10), Pair.of(2, 20), Pair.of(4, 40)));
+  }
 }


### PR DESCRIPTION
Implementation of Broadcast Join. Broadcast join can be very efficient for joins between a large dataset with small dataset that has to fit into memory.  It's implemented with Beam's `sideInput`. In this PR Broadcast Join doesn't work with windowing.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

