### PR TITLE
[BEAM-4560] Add posibility to define composite PTransform throught Euphoria API

### DIFF
--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/BeamExecutorContext.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/BeamExecutorContext.java
@@ -115,6 +115,13 @@ class BeamExecutorContext {
     }
   }
 
+  <T> void setFinishedPCollection(Dataset<T> dataset, PCollection<T> coll) {
+    final PCollection<?> prev = datasetToPCollection.put(dataset, coll);
+    if (prev != null && prev != coll) {
+      throw new IllegalStateException("Dataset(" + dataset + ") already materialized.");
+    }
+  }
+
   Pipeline getPipeline() {
     return pipeline;
   }

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/BeamPTransform.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/main/java/org/apache/beam/sdk/extensions/euphoria/beam/BeamPTransform.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.euphoria.beam;
+
+import java.util.Objects;
+import java.util.function.Function;
+import org.apache.beam.sdk.extensions.euphoria.core.client.dataset.Dataset;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+
+
+/**
+ * {@link PTransform} which allows you to build composite transformations in Euphoria API.
+ *
+ * @param <InputT> type of input elements
+ * @param <OutputT> type of output elements
+ */
+public class BeamPTransform<InputT, OutputT> extends
+    PTransform<PCollection<InputT>, PCollection<OutputT>> {
+
+  private final Function<Dataset<InputT>, Dataset<OutputT>> euphoriaTransform;
+
+  private BeamPTransform(
+      Function<Dataset<InputT>, Dataset<OutputT>> euphoriaTransform) {
+    this.euphoriaTransform = euphoriaTransform;
+  }
+
+  public static <InputT, OutputT> BeamPTransform<InputT, OutputT> of(
+      Function<Dataset<InputT>, Dataset<OutputT>> euphoriaDatasetTransform) {
+    Objects.requireNonNull(euphoriaDatasetTransform);
+    return new BeamPTransform<>(euphoriaDatasetTransform);
+  }
+
+  @Override
+  public PCollection<OutputT> expand(PCollection<InputT> input) {
+
+    BeamFlow flow = BeamFlow.create(input);
+    Dataset<InputT> wrappedInput = flow.wrapped(input);
+    Dataset<OutputT> output = euphoriaTransform.apply(wrappedInput);
+
+    return flow.unwrapped(output);
+  }
+
+}

--- a/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/org/apache/beam/sdk/extensions/euphoria/beam/BeamPTransformTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-beam/src/test/java/org/apache/beam/sdk/extensions/euphoria/beam/BeamPTransformTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.euphoria.beam;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.extensions.euphoria.core.client.dataset.Dataset;
+import org.apache.beam.sdk.extensions.euphoria.core.client.io.ListDataSource;
+import org.apache.beam.sdk.extensions.euphoria.core.client.operator.CountByKey;
+import org.apache.beam.sdk.extensions.euphoria.core.client.operator.MapElements;
+import org.apache.beam.sdk.extensions.euphoria.core.client.util.Pair;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * A group of test focused at {@link BeamPTransform}.
+ */
+public class BeamPTransformTest implements Serializable {
+
+  private static final String BASE_STRING =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et imperdiet nulla,"
+          + " vulputate luctus risus. In sed suscipit purus. Curabitur dui eros, eleifend sed "
+          + "dignissim eget, euismod sed lorem.";
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+
+  @Test
+  public void basicBeamTransformTest() {
+
+    final List<String> words = Arrays.asList(BASE_STRING.split(" "));
+    final List<String> upperCaseWords = Arrays.asList(BASE_STRING.toUpperCase().split(" "));
+
+    final PCollection<String> pCollection =
+        pipeline
+            .apply("Create", Create.of(words).withCoder(StringUtf8Coder.of()))
+            .apply("To-UpperCase", BeamPTransform.of(
+                input -> MapElements
+                    .of(input)
+                    .using(s -> s.toUpperCase())
+                    .output()
+            ));
+
+    PAssert.that(pCollection).containsInAnyOrder(upperCaseWords);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testChainedOperations() {
+
+    String inStr = "a b c a a c x";
+    final List<String> words = Arrays.asList(inStr.split(" "));
+
+    final PCollection<Pair<String, Long>> pCollection =
+        pipeline
+            .apply("Create", Create.of(words).withCoder(StringUtf8Coder.of()))
+            .apply("To-UpperCase", BeamPTransform.of((Dataset<String> input) -> {
+                  Dataset<String> upperCase = MapElements
+                      .of(input)
+                      .using(s -> s.toUpperCase())
+                      .output();
+
+                  return CountByKey
+                      .of(upperCase)
+                      .keyBy(e -> e)
+                      .output();
+                }
+            ));
+
+    PAssert.that(pCollection).containsInAnyOrder(Pair.of("A", 3L), Pair.of("B", 1L),
+        Pair.of("C", 2L), Pair.of("X", 1L));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testBeamTransformWhenFlowIsExecuted() {
+
+    final List<String> words = Arrays.asList(BASE_STRING.split(" "));
+    final List<String> upperCaseWords = Arrays.asList(BASE_STRING.toUpperCase().split(" "));
+
+    final PCollection<String> pCollection =
+        pipeline
+            .apply("Create", Create.of(words).withCoder(StringUtf8Coder.of()))
+            .apply("To-UpperCase", BeamPTransform.of(
+                input -> MapElements
+                    .of(input)
+                    .using(s -> s.toUpperCase())
+                    .output()
+            ));
+
+    PAssert.that(pCollection).containsInAnyOrder(upperCaseWords);
+
+    BeamFlow flow = BeamFlow.create(pipeline);
+    BeamExecutor executor = TestUtils.createExecutor();
+    executor.execute(flow);
+  }
+
+  @Test
+  public void testFlowToPCollection() {
+
+    BeamFlow flow = BeamFlow.create(pipeline);
+
+    final ListDataSource<Integer> input =
+        ListDataSource.unbounded(Arrays.asList(1, 2, 3), Arrays.asList(4, 5, 6));
+    Dataset<Integer> inputDataset = flow.createInput(input);
+
+    //final ListDataSink<Integer> output = ListDataSink.get();
+    Dataset<Integer> plusOne = MapElements.of(inputDataset).using(i -> i + 1).output();
+
+    PCollection<Integer> unwrapped = flow.unwrapped(plusOne);
+
+    PCollection<Integer> twicePcollection = unwrapped.apply("Twice", BeamPTransform.of(
+        in -> MapElements.of(in).using(i -> 2 * i).output()
+    ));
+
+    PAssert.that(twicePcollection).containsInAnyOrder(4, 6, 8, 10, 12, 14);
+
+    pipeline.run();
+  }
+
+}


### PR DESCRIPTION
`BeamPTransform` allows to describe Beam's `PTransform` using Euphoria API. It is designed to have similar API as Operators do.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

