### PR TITLE
[BEAM-5205] Use chunked Kryo encoding instead of our own chunking

### DIFF
--- a/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/IdentifiedRegistrar.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/IdentifiedRegistrar.java
@@ -21,6 +21,8 @@ import com.esotericsoftware.kryo.Kryo;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link KryoRegistrar} enriched by Id.
@@ -32,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * enriched by Id.
  */
 class IdentifiedRegistrar implements Serializable {
+  private static final Logger LOG = LoggerFactory.getLogger(RegisterCoders.class);
 
   private static final AtomicInteger idSource = new AtomicInteger();
 
@@ -45,7 +48,20 @@ class IdentifiedRegistrar implements Serializable {
 
   static IdentifiedRegistrar of(KryoRegistrar registrar) {
     Objects.requireNonNull(registrar);
-    return new IdentifiedRegistrar(idSource.getAndIncrement(), registrar);
+    IdentifiedRegistrar identifiedRegistrar =
+        new IdentifiedRegistrar(idSource.getAndIncrement(), registrar);
+    LOG.info(
+        String.format(
+            "Id: '%d' was assigned to given %s of type '%s'.",
+            identifiedRegistrar.getId(),
+            KryoRegistrar.class.getSimpleName(),
+            registrar.getClass()));
+    return identifiedRegistrar;
+  }
+
+  @Override
+  public String toString() {
+    return "IdentifiedRegistrar{" + "id=" + id + ", registrar=" + registrar + '}';
   }
 
   public int getId() {

--- a/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/KryoCoder.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/KryoCoder.java
@@ -78,8 +78,8 @@ public class KryoCoder<T> extends CustomCoder<T> {
       throw new CoderException(
           String.format(
               "Cannot encode given object of type '%s'. "
-                  + "Forgotten kryo registration is possible explanation.",
-              (value == null) ? null : value.getClass().getSimpleName()),
+                  + "Forgotten kryo registration is possible explanation. Kryo registrations where done by '%s'.",
+              (value == null) ? null : value.getClass().getSimpleName(), registrarWithId),
           e);
     }
   }
@@ -100,7 +100,10 @@ public class KryoCoder<T> extends CustomCoder<T> {
 
     } catch (KryoException e) {
       throw new CoderException(
-          "Cannot decode object from input stream. Forgotten kryo registration is possible explanation.",
+          String.format(
+              "Cannot decode object from input stream."
+                  + " Forgotten kryo registration is possible explanation. Kryo registrations where done by '%s'.",
+              registrarWithId),
           e);
     }
   }

--- a/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/KryoCoder.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/KryoCoder.java
@@ -19,16 +19,13 @@ package org.apache.beam.sdk.extensions.euphoria.core.translate.coder;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoException;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
+import com.esotericsoftware.kryo.io.InputChunked;
+import com.esotericsoftware.kryo.io.OutputChunked;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.CustomCoder;
-import org.apache.commons.compress.utils.BoundedInputStream;
 
 /**
  * Coder using Kryo as (de)serialization mechanism. See {@link RegisterCoders} to get more details
@@ -67,11 +64,16 @@ public class KryoCoder<T> extends CustomCoder<T> {
   @Override
   public void encode(T value, OutputStream outStream) throws IOException {
 
-    Output output = KryoFactory.getKryoOutput();
-    output.clear();
     Kryo kryo = KryoFactory.getOrCreateKryo(registrarWithId);
+
+    OutputChunked output = KryoFactory.getKryoOutput();
+    output.clear();
+    output.setOutputStream(outStream);
+
     try {
       kryo.writeClassAndObject(output, value);
+      output.endChunks();
+      output.flush();
     } catch (IllegalArgumentException e) {
       throw new CoderException(
           String.format(
@@ -80,40 +82,25 @@ public class KryoCoder<T> extends CustomCoder<T> {
               (value == null) ? null : value.getClass().getSimpleName()),
           e);
     }
-
-    DataOutputStream dos = new DataOutputStream(outStream);
-    // write length of encoded object first to get ability to limit read in decode() to one object
-    dos.writeInt(output.position());
-    outStream.write(output.getBuffer(), 0, output.position());
   }
 
   @Override
   public T decode(InputStream inStream) throws IOException {
 
-    // read length of objects in bytes first
-    DataInputStream dis = new DataInputStream(inStream);
-    int lengthOfDecodedObject = dis.readInt();
-
-    Input input = KryoFactory.getKryoInput();
-
-    // limit the input stream to not allow kryo to read beyond the current object
-    BoundedInputStream limitedStream = new BoundedInputStream(inStream, lengthOfDecodedObject);
-    input.setInputStream(limitedStream);
+    InputChunked input = KryoFactory.getKryoInput();
+    input.rewind();
+    input.setInputStream(inStream);
 
     Kryo kryo = KryoFactory.getOrCreateKryo(registrarWithId);
 
     try {
-
       @SuppressWarnings("unchecked")
       T outObject = (T) kryo.readClassAndObject(input);
       return outObject;
 
     } catch (KryoException e) {
       throw new CoderException(
-          String.format(
-              "Cannot decode object of length %d bytes from input stream. "
-                  + "Forgotten kryo registration is possible explanation.",
-              lengthOfDecodedObject),
+          "Cannot decode object from input stream. Forgotten kryo registration is possible explanation.",
           e);
     }
   }

--- a/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/KryoFactory.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/KryoFactory.java
@@ -19,7 +19,9 @@ package org.apache.beam.sdk.extensions.euphoria.core.translate.coder;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.InputChunked;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.io.OutputChunked;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -60,11 +62,11 @@ class KryoFactory {
     return instance;
   }
 
-  private static ThreadLocal<Output> threadLocalOutput =
-      ThreadLocal.withInitial(() -> new Output(DEFAULT_BUFFER_SIZE, -1));
+  private static ThreadLocal<OutputChunked> threadLocalOutput =
+      ThreadLocal.withInitial(() -> new OutputChunked(DEFAULT_BUFFER_SIZE));
 
-  private static ThreadLocal<Input> threadLocalInput =
-      ThreadLocal.withInitial(() -> new Input(DEFAULT_BUFFER_SIZE));
+  private static ThreadLocal<InputChunked> threadLocalInput =
+      ThreadLocal.withInitial(() -> new InputChunked(DEFAULT_BUFFER_SIZE));
 
   /**
    * We need an instance of {@link KryoRegistrar} to do actual {@link Kryo} registration. But since
@@ -101,11 +103,11 @@ class KryoFactory {
     }
   }
 
-  static Input getKryoInput() {
+  static InputChunked getKryoInput() {
     return threadLocalInput.get();
   }
 
-  static Output getKryoOutput() {
+  static OutputChunked getKryoOutput() {
     return threadLocalOutput.get();
   }
 }


### PR DESCRIPTION
`KryoCoder` now use Kryo's chunked output/input.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




