### PR TITLE
[BEAM-5276] `ListDataSource` should not enforce data items to be serializable

### DIFF
--- a/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/functional/Supplier.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/functional/Supplier.java
@@ -1,0 +1,22 @@
+package org.apache.beam.sdk.extensions.euphoria.core.client.functional;
+
+import java.io.Serializable;
+
+/**
+ * Represents a serializable supplier of some object.
+ *
+ * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
+ * {@link #get()}.
+ *
+ * @param <T> the type of results supplied by this supplier
+ */
+@FunctionalInterface
+public interface Supplier<T> extends Serializable {
+
+  /**
+   * Gets a supplied object.
+   *
+   * @return a result
+   */
+  T get();
+}

--- a/sdks/java/extensions/euphoria/euphoria-core/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/client/io/ListDataSourceTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/client/io/ListDataSourceTest.java
@@ -1,0 +1,92 @@
+package org.apache.beam.sdk.extensions.euphoria.core.client.io;
+
+import java.util.Collections;
+import java.util.Objects;
+import org.apache.beam.sdk.extensions.euphoria.core.client.dataset.Dataset;
+import org.apache.beam.sdk.extensions.euphoria.core.translate.BeamFlow;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Unit test of {@link ListDataSource}. */
+public class ListDataSourceTest {
+
+  @Rule public TestPipeline pipeline = TestPipeline.create();
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCannotCreateInputPCollectionWhenItemsNotSerializable() {
+    BeamFlow flow = BeamFlow.of(pipeline);
+
+    DataSource<NotSerializableClass> source =
+        ListDataSource.bounded(
+            Collections.singletonList(new NotSerializableClass("just-some-text")));
+
+    Dataset<NotSerializableClass> inputDataset = flow.createInput(source);
+
+    pipeline.run();
+  }
+
+  @Test()
+  public void testCanCreateInputPCollectionWhenItemsNotSerializable() {
+    BeamFlow flow = BeamFlow.of(pipeline);
+
+    DataSource<NotSerializableClass> source =
+        ListDataSource.bounded(
+            () ->
+                Collections.singletonList(
+                    Collections.singletonList(new NotSerializableClass("just-some-text"))));
+
+    Dataset<NotSerializableClass> inputDataset = flow.createInput(source);
+
+    PAssert.that(flow.unwrapped(inputDataset))
+        .containsInAnyOrder(new NotSerializableClass("just-some-text"));
+
+    pipeline.run();
+  }
+
+  @Test()
+  public void testCanCreateInputPCollectionWhenItemsNotSerializableOnePartition() {
+    BeamFlow flow = BeamFlow.of(pipeline);
+
+    DataSource<NotSerializableClass> source =
+        ListDataSource.boundedOnePartiton(
+            () -> Collections.singletonList(new NotSerializableClass("just-some-text")));
+
+    Dataset<NotSerializableClass> inputDataset = flow.createInput(source);
+
+    PAssert.that(flow.unwrapped(inputDataset))
+        .containsInAnyOrder(new NotSerializableClass("just-some-text"));
+
+    pipeline.run();
+  }
+
+  private static class NotSerializableClass {
+    private final Object someData;
+
+    public NotSerializableClass(Object someData) {
+      this.someData = someData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      NotSerializableClass that = (NotSerializableClass) o;
+      return Objects.equals(someData, that.someData);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(someData);
+    }
+
+    public Object getSomeData() {
+      return someData;
+    }
+  }
+}


### PR DESCRIPTION
Data items lazy fetching added to `ListDataSource` to avoid items serialization. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




