### PR TITLE
[BEAM-5343] SingleJvmAccumulatorProvider fix

### DIFF
--- a/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/accumulators/AccumulatorProvider.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/accumulators/AccumulatorProvider.java
@@ -43,9 +43,7 @@ public interface AccumulatorProvider {
    * @param name of the counter
    * @return Instance of a counter.
    */
-  default Counter getCounter(String namespace, String name) {
-    return getCounter(name);
-  }
+  Counter getCounter(String namespace, String name);
   /**
    * Get an existing instance of a histogram or create a new one.
    *
@@ -61,9 +59,7 @@ public interface AccumulatorProvider {
    * @param name of the counter
    * @return Instance of a counter.
    */
-  default Histogram getHistogram(String namespace, String name) {
-    return getHistogram(name);
-  }
+  Histogram getHistogram(String namespace, String name);
 
   /**
    * Get an existing instance of a timer or create a new one.

--- a/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/accumulators/VoidAccumulatorProvider.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/accumulators/VoidAccumulatorProvider.java
@@ -45,7 +45,17 @@ public class VoidAccumulatorProvider implements AccumulatorProvider {
   }
 
   @Override
+  public Counter getCounter(String namespace, String name) {
+    return VoidCounter.INSTANCE;
+  }
+
+  @Override
   public Histogram getHistogram(String name) {
+    return VoidHistogram.INSTANCE;
+  }
+
+  @Override
+  public Histogram getHistogram(String namespace, String name) {
     return VoidHistogram.INSTANCE;
   }
 

--- a/sdks/java/extensions/euphoria/euphoria-core/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/testkit/accumulators/SingleJvmAccumulatorProvider.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/testkit/accumulators/SingleJvmAccumulatorProvider.java
@@ -64,9 +64,19 @@ public class SingleJvmAccumulatorProvider implements AccumulatorProvider {
   }
 
   @Override
+  public Counter getCounter(String namespace, String name) {
+    return getCounter(name);
+  }
+
+  @Override
   public Histogram getHistogram(String name) {
     return assertType(
         name, LongHistogram.class, accs.computeIfAbsent(name, s -> new LongHistogram()));
+  }
+
+  @Override
+  public Histogram getHistogram(String namespace, String name) {
+    return getHistogram(name);
   }
 
   @Override
@@ -101,6 +111,11 @@ public class SingleJvmAccumulatorProvider implements AccumulatorProvider {
 
     private Factory() {}
 
+    /**
+     * Before running another test, clear method must be called to delete metrics snapshots
+     *
+     * @return SingleJvmAccumulatorFactory
+     */
     public static Factory get() {
       return INSTANCE;
     }

--- a/sdks/java/extensions/euphoria/euphoria-core/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/translate/SingleJvmAccumulatorProviderTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/translate/SingleJvmAccumulatorProviderTest.java
@@ -24,8 +24,8 @@ import org.apache.beam.sdk.extensions.euphoria.core.client.accumulators.Histogra
 import org.apache.beam.sdk.extensions.euphoria.core.testkit.accumulators.SingleJvmAccumulatorProvider;
 import org.apache.beam.sdk.extensions.euphoria.core.testkit.accumulators.SingleJvmAccumulatorProvider.Factory;
 import org.apache.beam.sdk.extensions.euphoria.core.util.Settings;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -38,16 +38,13 @@ public class SingleJvmAccumulatorProviderTest {
   private static final String TEST_COUNTER_NAME = "test-counter";
   private static final String TEST_HISTOGRAM_NAME = "test-histogram";
 
-  @Ignore(
-      "Clashes with SingleValueCollectorTest since SingleJvmAccumulatorProvider do not respects namespaces.")
+  private Factory accFactory = Factory.get();
+
   @Test
   public void testBasicAccumulatorsFunction() {
-
-    Factory accFactory = Factory.get();
     final AccumulatorProvider accumulators = accFactory.create(new Settings());
 
     Counter counter = accumulators.getCounter(TEST_COUNTER_NAME);
-    System.out.println("counter: " + counter);
     Assert.assertNotNull(counter);
 
     counter.increment();
@@ -72,5 +69,13 @@ public class SingleJvmAccumulatorProviderTest {
     Assert.assertEquals(2L, numOfValuesOfTwo);
 
     // collector.getTimer() <- not yet supported
+  }
+
+  /**
+   * need to delete all metrics from accumulator before running another test
+   */
+  @After
+  public void cleanUp() {
+    accFactory.clear();
   }
 }

--- a/sdks/java/extensions/euphoria/euphoria-core/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/translate/collector/SingleValueCollectorTest.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/translate/collector/SingleValueCollectorTest.java
@@ -24,6 +24,7 @@ import org.apache.beam.sdk.extensions.euphoria.core.client.accumulators.Histogra
 import org.apache.beam.sdk.extensions.euphoria.core.testkit.accumulators.SingleJvmAccumulatorProvider;
 import org.apache.beam.sdk.extensions.euphoria.core.testkit.accumulators.SingleJvmAccumulatorProvider.Factory;
 import org.apache.beam.sdk.extensions.euphoria.core.util.Settings;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,11 +36,12 @@ public class SingleValueCollectorTest {
   private static final String TEST_COUNTER_NAME = "test-counter";
   private static final String TEST_HISTOGRAM_NAME = "test-histogram";
 
+  Factory singleJVMaccFactory = SingleJvmAccumulatorProvider.Factory.get();
+
   @Test
   public void testBasicAccumulatorsAccess() {
 
-    final AccumulatorProvider accumulators =
-        SingleJvmAccumulatorProvider.Factory.get().create(new Settings());
+    final AccumulatorProvider accumulators = singleJVMaccFactory.create(new Settings());
 
     SingleValueCollector collector = new SingleValueCollector(accumulators, "test-no_op_name");
 
@@ -54,9 +56,7 @@ public class SingleValueCollectorTest {
 
   @Test
   public void testBasicAccumulatorsFunction() {
-
-    Factory accFactory = Factory.get();
-    final AccumulatorProvider accumulators = accFactory.create(new Settings());
+    final AccumulatorProvider accumulators = singleJVMaccFactory.create(new Settings());
 
     SingleValueCollector collector = new SingleValueCollector(accumulators, "test-no_op_name");
 
@@ -66,7 +66,7 @@ public class SingleValueCollectorTest {
     counter.increment();
     counter.increment(2);
 
-    Map<String, Long> counterSnapshots = accFactory.getCounterSnapshots();
+    Map<String, Long> counterSnapshots = singleJVMaccFactory.getCounterSnapshots();
     long counteValue = counterSnapshots.get(TEST_COUNTER_NAME);
     Assert.assertEquals(3L, counteValue);
 
@@ -76,7 +76,7 @@ public class SingleValueCollectorTest {
     histogram.add(1);
     histogram.add(2, 2);
 
-    Map<String, Map<Long, Long>> histogramSnapshots = accFactory.getHistogramSnapshots();
+    Map<String, Map<Long, Long>> histogramSnapshots = singleJVMaccFactory.getHistogramSnapshots();
     Map<Long, Long> histogramValue = histogramSnapshots.get(TEST_HISTOGRAM_NAME);
 
     long numOfValuesOfOne = histogramValue.get(1L);
@@ -85,5 +85,13 @@ public class SingleValueCollectorTest {
     Assert.assertEquals(2L, numOfValuesOfTwo);
 
     // collector.getTimer() <- not yet supported
+  }
+
+  /**
+   * need to delete all metrics from accumulator before running another test
+   */
+  @After
+  public void cleanUp() {
+    singleJVMaccFactory.clear();
   }
 }


### PR DESCRIPTION
`SingleJvmAccumulatorProvider` needs to clear all metrics after test otherwise it could collide with another test, which uses same metrics name

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




