### PR TITLE
[BEAM-5373] Kryo NO-OP registrars can swap IDs between JVMs

### DIFF
--- a/sdks/java/extensions/euphoria/euphoria-core/build.gradle
+++ b/sdks/java/extensions/euphoria/euphoria-core/build.gradle
@@ -27,7 +27,7 @@ ext {
 
 dependencies {
     shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
-    compile "com.esotericsoftware:kryo:${kryoVersion}"
+    shadow "com.esotericsoftware:kryo:${kryoVersion}"
     shadow library.java.guava
     testCompile library.java.mockito_core
     testCompile project(path: ':beam-sdks-java-extensions-euphoria-testing')

--- a/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/IdentifiedRegistrar.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/IdentifiedRegistrar.java
@@ -34,6 +34,8 @@ import org.slf4j.LoggerFactory;
  * enriched by Id.
  */
 class IdentifiedRegistrar implements Serializable {
+
+  static final int NO_OP_REGISTRAR_ID = -1;
   private static final Logger LOG = LoggerFactory.getLogger(RegisterCoders.class);
 
   private static final AtomicInteger idSource = new AtomicInteger();
@@ -57,6 +59,14 @@ class IdentifiedRegistrar implements Serializable {
             KryoRegistrar.class.getSimpleName(),
             registrar.getClass()));
     return identifiedRegistrar;
+  }
+
+  static IdentifiedRegistrar defaultNoOpRegistrar() {
+    return new IdentifiedRegistrar(
+        NO_OP_REGISTRAR_ID,
+        (kryo) -> {
+          /*No-Op*/
+        });
   }
 
   @Override

--- a/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/KryoFactory.java
+++ b/sdks/java/extensions/euphoria/euphoria-core/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/translate/coder/KryoFactory.java
@@ -43,7 +43,7 @@ class KryoFactory {
    * <p>{@link #getOrCreateKryo(IdentifiedRegistrar)} returns {@link Kryo} which allows for
    * serialization of unregistered classes when this {@link IdentifiedRegistrar} is used to call it.
    */
-  static final IdentifiedRegistrar NO_OP_REGISTRAR = IdentifiedRegistrar.of((k) -> {});
+  static final IdentifiedRegistrar NO_OP_REGISTRAR = IdentifiedRegistrar.defaultNoOpRegistrar();
 
   private static Kryo createKryo(IdentifiedRegistrar registrarWithId) {
     final Kryo instance = new Kryo();
@@ -52,7 +52,7 @@ class KryoFactory {
 
     // mere NO_OP_REGISTRAR == registrarWithId is not enough since
     // NO_OP_REGISTRAR can be deserialized into several instances
-    if (NO_OP_REGISTRAR.getId() == registrarWithId.getId()) {
+    if (registrarWithId.getId() == IdentifiedRegistrar.NO_OP_REGISTRAR_ID) {
       instance.setRegistrationRequired(false);
     } else {
       instance.setRegistrationRequired(true);


### PR DESCRIPTION
No-Op registrar now has id of its own. Kryo dependency changed to 'shadow'.
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




